### PR TITLE
Update travis.yml to move on Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
   fast_finish: true
   include:
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: false
       jdk: openjdk8
 


### PR DESCRIPTION
Trusty have a bug with update-alternatives on javac, it brings javac 9.0 instead of java 8.0 -> moving to Xenial